### PR TITLE
Add GUILE_LOAD_PATH from direnv to geiser-guile-load-path

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -6,7 +6,9 @@
   (eval . (with-eval-after-load 'geiser-guile
             (let ((root-dir
                    (file-name-directory
-                    (locate-dominating-file default-directory ".dir-locals.el"))))
+                    (locate-dominating-file default-directory ".dir-locals.el")))
+                  (env-paths (split-string (getenv "GUILE_LOAD_PATH") ":")))
+              (when env-paths (setq-local geiser-guile-load-path env-paths))
               (unless (member root-dir geiser-guile-load-path)
                 (setq-local geiser-guile-load-path
                             (cons root-dir geiser-guile-load-path)))))))


### PR DESCRIPTION
This is more of a question rather than something really useful.

 Since direnv is changing at the last moment GUILE_LOAD_PATH (with `path_add`), shouldn't there be as well this kind of snippet in the dir-locals so that when you use a manifest which has more 3rd party code, it also gets picked up properly in `geiser-guile-load-path` ?

Sorry for the intrusion (feel free to close whenever, I find easier to discuss over patches)